### PR TITLE
Add Willow display-tree rendering library   

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ If you see a package or project here that is no longer maintained or is not a go
 * [bitmapfont](https://github.com/hajimehoshi/bitmapfont) - A plug-and-play `font.Face`, that supports a wide range of languages and symbols
 * [bitsweetfont](https://github.com/quasilyte/bitsweetfont) - A plug-and-play `font.Face` that has limited language support, but has multiple sizes
 * [shapes](https://github.com/erparts/go-shapes) — A lightweight Ebitengine package for drawing common 2D shapes and simple effects.
+* [willow](https://github.com/devthicket/willow) - A display-tree 2D rendering layer for Ebitengine with batching, cameras, culling, and hit detection. Inspired by Starling and PixiJS, with a focus on performance.
 
 ### Video
 


### PR DESCRIPTION
 Adds [Willow](https://github.com/devthicket/willow) to the Graphics section.
                                                                              
  Willow is a display-tree 2D rendering layer for Ebitengine with batching, cameras,
  culling, and hit detection. Inspired by Starling and PixiJS, with a focus on           
  performance.     